### PR TITLE
feat(#14): support responseType "base64" in $http / fetch for binary responses

### DIFF
--- a/Shared/ScriptWidgetRuntime/Resource/Script.bundle/api/http/main.jsx
+++ b/Shared/ScriptWidgetRuntime/Resource/Script.bundle/api/http/main.jsx
@@ -54,6 +54,20 @@ console.log(post_string_with_header_result);
 // $http.patch (same to post)
 // $http.delete (same to post)
 
+// responseType: "base64"
+// By default the response is decoded as UTF-8 text. For binary resources
+// (such as images) pass responseType: "base64" to get the raw bytes back as
+// a Base64 string. This is useful when the resource needs custom headers
+// (e.g. a Referer / Cookie) that the <image url="..."> tag cannot send.
+//
+// const base64 = await $http.get("https://example.com/camera.jpg", {
+//   headers: { Referer: "https://example.com/webcam-page/" },
+//   responseType: "base64",
+// });
+// $render(
+//   <image url={`data:image/jpeg;base64,${base64}`} mode="fit" frame="340,340" />
+// );
+
 $render(
   <vstack>
     <text>$http example</text>

--- a/Shared/ScriptWidgetRuntime/Widget/API/ScriptWidgetRuntimeFetch.swift
+++ b/Shared/ScriptWidgetRuntime/Widget/API/ScriptWidgetRuntimeFetch.swift
@@ -78,9 +78,18 @@ let internal_fetch:@convention(block) (String, String, [AnyHashable : Any]?)-> S
             if let error = error {
                 print("$fetch error : \(error)")
                 reject.call(withArguments: [error.localizedDescription])
-            } else if let data = data, let string = String(data: data, encoding: String.Encoding.utf8) {
-                print("$fetch string: \(string)");
-                resolve.call(withArguments: [string])
+            } else if let data = data {
+                if let responseType = params?["responseType"] as? String, responseType == "base64" {
+                    let base64 = data.base64EncodedString()
+                    print("$fetch base64 length: \(base64.count)");
+                    resolve.call(withArguments: [base64])
+                } else if let string = String(data: data, encoding: String.Encoding.utf8) {
+                    print("$fetch string: \(string)");
+                    resolve.call(withArguments: [string])
+                } else {
+                    print("$fetch unable to decode response as utf8");
+                    reject.call(withArguments: ["\(urlValue) is empty"])
+                }
             } else {
                 print("$fetch unknown error");
                 reject.call(withArguments: ["\(urlValue) is empty"])


### PR DESCRIPTION
Closes #14.

## Problem

`$http.get` / `$http.post` / `fetch` always decode the response as UTF-8 text. When the server returns binary data (e.g. a JPEG), the decode fails and the promise rejects with `"<url> is empty"` — the bytes are lost. This makes it impossible to display images that require custom request headers (`Referer`, `Cookie`), since `<image url="...">` loads binary fine but can't send headers, while `$http.get` sends headers but couldn't return binary.

## Change

Add a `responseType: "base64"` option to the fetch params. When set, the raw response data is returned as a Base64 string instead of being UTF-8 decoded. Default behavior is unchanged (still returns a UTF-8 string), so this is non-breaking.

- `Shared/ScriptWidgetRuntime/Widget/API/ScriptWidgetRuntimeFetch.swift` — branch on `params["responseType"] == "base64"` in the completion handler.
- `Shared/ScriptWidgetRuntime/Resource/Script.bundle/api/http/main.jsx` — document the new option with a usage example.

## Usage

\`\`\`javascript
const base64 = await $http.get("https://example.com/camera.jpg", {
  headers: { Referer: "https://example.com/webcam-page/" },
  responseType: "base64",
});

$render(
  <image url={\`data:image/jpeg;base64,\${base64}\`} mode="fit" frame="340,340" />
);
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)